### PR TITLE
remove log1pexp with logistic function to correct inverted labels

### DIFF
--- a/chapter04/logitBinPred.m
+++ b/chapter04/logitBinPred.m
@@ -9,6 +9,5 @@ function [y, p] = logitBinPred(model, X)
 % Written by Mo Chen (sth4nth@gmail.com).
 X = [X;ones(1,size(X,2))];
 w = model.w;
-p = exp(-log1pexp(w'*X));
+p = 1 ./ (1 + exp(-w' * X));
 y = round(p);
-

--- a/chapter04/logitBinPred.m
+++ b/chapter04/logitBinPred.m
@@ -9,6 +9,6 @@ function [y, p] = logitBinPred(model, X)
 % Written by Mo Chen (sth4nth@gmail.com).
 X = [X;ones(1,size(X,2))];
 w = model.w;
-p = exp(-log1pexp(w'*X)); 
+p = exp(-log1pexp(w'*X));
 y = round(p);
 


### PR DESCRIPTION
I am unclear on the use of `log1pexp.m`; it may be more efficient than the proposed implementation here, but this fixes the inverted labels problem and I'll be using this version of the script for now. Thanks for considering!